### PR TITLE
CPH - Allow RTRs to be searchable in SAS

### DIFF
--- a/include/handlers.h
+++ b/include/handlers.h
@@ -600,6 +600,7 @@ private:
   void dissociate_implicit_registration_sets();
   void delete_impi_mappings();
   void send_rta(const std::string result_code);
+  void log_sip_all_register_marker(const std::string uri);
 };
 
 class PushProfileTask : public Diameter::Task

--- a/include/handlers.h
+++ b/include/handlers.h
@@ -600,7 +600,6 @@ private:
   void dissociate_implicit_registration_sets();
   void delete_impi_mappings();
   void send_rta(const std::string result_code);
-  void log_sip_all_register_marker(const std::string uri);
 };
 
 class PushProfileTask : public Diameter::Task
@@ -657,7 +656,6 @@ private:
   void update_reg_data_failure(CassandraStore::Operation* op,
                                CassandraStore::ResultCode error,
                                std::string& text);
-  void log_sip_all_register_marker(const std::string uri);
   void send_ppa(const std::string result_code);
 };
 

--- a/include/handlers.h
+++ b/include/handlers.h
@@ -657,6 +657,7 @@ private:
   void update_reg_data_failure(CassandraStore::Operation* op,
                                CassandraStore::ResultCode error,
                                std::string& text);
+  void log_sip_all_register_marker(const std::string uri);
   void send_ppa(const std::string result_code);
 };
 

--- a/src/handlers.cpp
+++ b/src/handlers.cpp
@@ -1979,6 +1979,11 @@ void RegistrationTerminationTask::run()
   TRC_INFO("Received Registration-Termination request with dereg reason %d",
            _deregistration_reason);
 
+  // Log start of trail and "RTR received" event. SIP_ALL_REGISTER markers will be added
+  // for each IMPU once we have determined the list of IMPUs to unregister.
+  SAS::Marker init_time(trail(), MARKER_ID_START, 1u);
+  SAS::report_marker(init_time);
+
   SAS::Event rtr_received(trail(), SASEvent::RTR_RECEIVED, 0);
   rtr_received.add_var_param(impi);
   rtr_received.add_static_param(associated_identities.size());
@@ -2164,7 +2169,12 @@ void RegistrationTerminationTask::delete_registrations()
        i != _registration_sets.end();
        i++)
   {
-    default_public_identities.push_back((*i)[0]);
+    std::string default_impu = (*i)[0];
+
+    // Log IMPUs to SAS as SIP_ALL_REGISTER markers so this RTR shows up in search results for the IMPU.
+    log_sip_all_register_marker(default_impu);
+
+    default_public_identities.push_back(default_impu);
   }
 
   // We need to notify sprout of the deregistrations. What we send to sprout depends
@@ -2316,6 +2326,60 @@ void RegistrationTerminationTask::send_rta(const std::string result_code)
   // Send the RTA back to the HSS.
   TRC_INFO("Ready to send RTA");
   rta.send(trail());
+}
+
+void RegistrationTerminationTask::log_sip_all_register_marker(const std::string uri)
+{
+  std::string stripped_uri(uri);
+  std::string user;
+  bool is_tel_uri = false;
+  bool user_is_numeric = true;
+
+  // Strip the scheme off the URI. We expect the scheme to be present, but
+  // cope with the case where it isn't.
+  size_t colon = stripped_uri.find(':');
+
+  if (colon != std::string::npos)
+  {
+    is_tel_uri = (stripped_uri.find("tel:") == 0);
+    stripped_uri.erase(0, colon + 1);
+  }
+
+  // Extract the user part of the URI and check if it is numeric, i.e. a DN.
+  for (size_t i = 0; (i < stripped_uri.length()) && (stripped_uri[i] != '@'); i++)
+  {
+    char c = stripped_uri[i];
+
+    // In case a tel: URI has still got the visual separators included (which it shouldn't),
+    // strip them off.
+    if (is_tel_uri &&
+        ((c == '(') || (c == ')') || (c == '-') || (c == '.')))
+    {
+      continue;
+    }
+
+    if (((c >= '0') && (c <= '9')) || (c == '+'))
+    {
+      user.push_back(c);
+    }
+    else
+    {
+      user_is_numeric = false;
+      break;
+    }
+  }
+
+  // Log the marker with the stripped URI as the first parameter, and the
+  // DN (if the URI can be interpreted as such) as the second parameter.
+  SAS::Marker sip_all_register(trail(), MARKER_ID_SIP_ALL_REGISTER, 1u);
+  sip_all_register.add_var_param(stripped_uri);
+
+  if (user_is_numeric)
+  {
+    sip_all_register.add_var_param(user);
+  }
+
+  SAS::report_marker(sip_all_register);
 }
 
 void PushProfileTask::run()

--- a/src/handlers.cpp
+++ b/src/handlers.cpp
@@ -2017,7 +2017,7 @@ void RegistrationTerminationTask::run()
   }
   else
   {
-    // This is either an invalid deregistration reason.
+    // This is an invalid deregistration reason.
     TRC_ERROR("Registration-Termination request received with invalid deregistration reason %d",
               _deregistration_reason);
     SAS::Event event(this->trail(), SASEvent::INVALID_DEREG_REASON, 0);
@@ -2330,43 +2330,19 @@ void RegistrationTerminationTask::send_rta(const std::string result_code)
 
 void RegistrationTerminationTask::log_sip_all_register_marker(const std::string uri)
 {
-  std::string stripped_uri(uri);
-  std::string user;
-  bool is_tel_uri = false;
-  bool user_is_numeric = true;
+  std::string stripped_uri;
 
   // Strip the scheme off the URI. We expect the scheme to be present, but
   // cope with the case where it isn't.
-  size_t colon = stripped_uri.find(':');
+  stripped_uri = Utils::strip_uri_scheme(uri);
 
-  if (colon != std::string::npos)
+  // Extract the user part from the remaining URI.
+  std::string user(stripped_uri);
+  size_t at = user.find('@');
+
+  if (at != std::string::npos)
   {
-    is_tel_uri = (stripped_uri.find("tel:") == 0);
-    stripped_uri.erase(0, colon + 1);
-  }
-
-  // Extract the user part of the URI and check if it is numeric, i.e. a DN.
-  for (size_t i = 0; (i < stripped_uri.length()) && (stripped_uri[i] != '@'); i++)
-  {
-    char c = stripped_uri[i];
-
-    // In case a tel: URI has still got the visual separators included (which it shouldn't),
-    // strip them off.
-    if (is_tel_uri &&
-        ((c == '(') || (c == ')') || (c == '-') || (c == '.')))
-    {
-      continue;
-    }
-
-    if (((c >= '0') && (c <= '9')) || (c == '+'))
-    {
-      user.push_back(c);
-    }
-    else
-    {
-      user_is_numeric = false;
-      break;
-    }
+    user.erase(at, std::string::npos);
   }
 
   // Log the marker with the stripped URI as the first parameter, and the
@@ -2374,9 +2350,9 @@ void RegistrationTerminationTask::log_sip_all_register_marker(const std::string 
   SAS::Marker sip_all_register(trail(), MARKER_ID_SIP_ALL_REGISTER, 1u);
   sip_all_register.add_var_param(stripped_uri);
 
-  if (user_is_numeric)
+  if (Utils::is_user_numeric(user))
   {
-    sip_all_register.add_var_param(user);
+    sip_all_register.add_var_param(Utils::remove_visual_separators(user));
   }
 
   SAS::report_marker(sip_all_register);

--- a/src/ut/handlers_test.cpp
+++ b/src/ut/handlers_test.cpp
@@ -1429,7 +1429,7 @@ const std::string HandlersTest::SERVER_NAME = "scscf";
 const std::string HandlersTest::IMPI = "_impi@example.com";
 const std::string HandlersTest::IMPU = "sip:impu@example.com";
 const std::string HandlersTest::IMPU2 = "sip:impu2@example.com";
-const std::string HandlersTest::IMPU3 = "sip:impu3@example.com";
+const std::string HandlersTest::IMPU3 = "sip:+44(208)3661177@example.com";
 const std::string HandlersTest::IMPU4 = "sip:impu4@example.com";
 const std::string HandlersTest::IMS_SUBSCRIPTION = "<?xml version=\"1.0\"?><IMSSubscription><PrivateID>" + IMPI + "</PrivateID><ServiceProfile><PublicIdentity><Identity>" + IMPU + "</Identity></PublicIdentity></ServiceProfile></IMSSubscription>";
 const std::string HandlersTest::REGDATA_RESULT = "<ClearwaterRegData>\n\t<RegistrationState>REGISTERED</RegistrationState>\n\t<IMSSubscription>\n\t\t<PrivateID>" + IMPI + "</PrivateID>\n\t\t<ServiceProfile>\n\t\t\t<PublicIdentity>\n\t\t\t\t<Identity>" + IMPU + "</Identity>\n\t\t\t</PublicIdentity>\n\t\t\t<PublicIdentity>\n\t\t\t\t<Identity>" + IMPU4 + "</Identity>\n\t\t\t</PublicIdentity>\n\t\t</ServiceProfile>\n\t</IMSSubscription>\n</ClearwaterRegData>\n\n";


### PR DESCRIPTION
Send all default IMPUs (with schemes and, for tel: URIs, visual separators stripped) as SIP_ALL_REGISTER markers to SAS.

- Needs unit test?
- URI formatting code ought to be put into a "utils" module of some sort but Homestead doesn't appear to have one

