### PR TITLE
Improve Monit polling behavior during monitored process restart

### DIFF
--- a/homestead.root/usr/share/clearwater/bin/check_cx_health
+++ b/homestead.root/usr/share/clearwater/bin/check_cx_health
@@ -36,3 +36,16 @@ set -ue
 . /etc/clearwater/config
 
 /usr/share/clearwater/bin/check_cx_health.py "${hss_server_error_tolerance:-20}"
+rc=$?
+
+# If the homestead process is not stable, we ignore a non-zero return code and
+# return zero.
+if [ $rc != 0 ]; then
+  /usr/share/clearwater/infrastructure/monit_stability/homestead-stability check
+  if [ $? != 0 ]; then
+    echo "return code $rc ignored" >&2
+    rc=0
+  fi
+fi
+
+exit $rc

--- a/homestead.root/usr/share/clearwater/bin/poll_homestead.sh
+++ b/homestead.root/usr/share/clearwater/bin/poll_homestead.sh
@@ -37,4 +37,17 @@
 . /etc/clearwater/config
 http_ip=$(/usr/share/clearwater/bin/bracket-ipv6-address $local_ip)
 /usr/share/clearwater/bin/poll-http $http_ip:8888
-exit $?
+
+rc=$?
+
+# If the homestead process is not stable, we ignore a non-zero return code and
+# return zero.
+if [ $rc != 0 ]; then
+  /usr/share/clearwater/infrastructure/monit_stability/homestead-stability check
+  if [ $? != 0 ]; then
+    echo "return code $rc ignored" >&2
+    rc=0
+  fi
+fi
+
+exit $rc

--- a/homestead.root/usr/share/clearwater/infrastructure/monit_stability/homestead-stability
+++ b/homestead.root/usr/share/clearwater/infrastructure/monit_stability/homestead-stability
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+# @file homestead-stability
+#
+# Copyright (C) Metaswitch Networks 2017
+# If license terms are provided to you in a COPYING file in the root directory
+# of the source code repository by which you are accessing this code, then
+# the license outlined in that COPYING file applies to your use.
+# Otherwise no rights are granted except for those provided to you by
+# Metaswitch Networks in a separate written agreement.
+
+# Used for monitoring the stability of the homestead process.
+
+PROCESS_NAME="homestead"
+GRACE_PERIOD=20
+
+method=$1
+
+/usr/share/clearwater/bin/process-stability $method $PROCESS_NAME $GRACE_PERIOD
+exit $?

--- a/homestead.root/usr/share/clearwater/infrastructure/scripts/homestead.monit
+++ b/homestead.root/usr/share/clearwater/infrastructure/scripts/homestead.monit
@@ -49,7 +49,7 @@ check process homestead_process with pidfile /var/run/homestead/homestead.pid
 
   # Check the service's resource usage, and abort the process if it's too high. This will
   # generate a core file and trigger diagnostics collection.
-  if memory > 40% then exec "/bin/bash -c '/usr/share/clearwater/infrastructure/monit_stability/homestead-stability aborted; /usr/share/clearwater/bin/issue-alarm monit 1500.3; /etc/init.d/homestead abort'"
+  if memory > 80% for 6 cycles then exec "/bin/bash -c '/usr/share/clearwater/infrastructure/monit_stability/homestead-stability aborted; /usr/share/clearwater/bin/issue-alarm monit 1500.3; /etc/init.d/homestead abort'"
 
 # Clear any alarms if the process has been running long enough.
 check program homestead_uptime with path /usr/share/clearwater/infrastructure/monit_uptime/check-homestead-uptime

--- a/homestead.root/usr/share/clearwater/infrastructure/scripts/homestead.monit
+++ b/homestead.root/usr/share/clearwater/infrastructure/scripts/homestead.monit
@@ -43,13 +43,13 @@ check process homestead_process with pidfile /var/run/homestead/homestead.pid
   group homestead
 
   # The start, stop and restart commands are linked to alarms
-  start program = "/bin/bash -c '/usr/share/clearwater/bin/issue-alarm monit 1500.3; /etc/init.d/homestead start'"
+  start program = "/bin/bash -c '/usr/share/clearwater/infrastructure/monit_stability/homestead-stability reset; /usr/share/clearwater/bin/issue-alarm monit 1500.3; /etc/init.d/homestead start'"
   stop program = "/bin/bash -c '/usr/share/clearwater/bin/issue-alarm monit 1500.3; /etc/init.d/homestead stop'"
-  restart program = "/bin/bash -c '/usr/share/clearwater/bin/issue-alarm monit 1500.3; /etc/init.d/homestead restart'"
+  restart program = "/bin/bash -c '/usr/share/clearwater/infrastructure/monit_stability/homestead-stability reset; /usr/share/clearwater/bin/issue-alarm monit 1500.3; /etc/init.d/homestead restart'"
 
   # Check the service's resource usage, and abort the process if it's too high. This will
   # generate a core file and trigger diagnostics collection.
-  if memory > 80% for 6 cycles then exec "/bin/bash -c '/usr/share/clearwater/bin/issue-alarm monit 1500.3; /etc/init.d/homestead abort'"
+  if memory > 40% then exec "/bin/bash -c '/usr/share/clearwater/infrastructure/monit_stability/homestead-stability aborted; /usr/share/clearwater/bin/issue-alarm monit 1500.3; /etc/init.d/homestead abort'"
 
 # Clear any alarms if the process has been running long enough.
 check program homestead_uptime with path /usr/share/clearwater/infrastructure/monit_uptime/check-homestead-uptime
@@ -65,7 +65,7 @@ check program poll_homestead with path "/usr/share/clearwater/bin/poll_homestead
   depends on homestead_process
 
   # Aborting generates a core file and triggers diagnostic collection.
-  if status != 0 for 2 cycles then exec "/bin/bash -c '/usr/share/clearwater/bin/issue-alarm monit 1500.3; /etc/init.d/homestead abort'"
+  if status != 0 for 2 cycles then exec "/bin/bash -c '/usr/share/clearwater/infrastructure/monit_stability/homestead-stability aborted; /usr/share/clearwater/bin/issue-alarm monit 1500.3; /etc/init.d/homestead abort'"
 
 
 # Check the Diameter interface. This depends on the Homestead process (and so won't run
@@ -84,7 +84,7 @@ check program check_cx_health with path "/usr/share/clearwater/bin/check_cx_heal
   # (Check for 2 cycles to get round monit's limitation of effectively checking exit codes one cycle
   # late.  If you don't wait for at least 2 consecutive cycles, you can end up with monit erroneously
   # killing homestead twice)
-  if status = 3 for 2 cycles then exec "/bin/bash -c '/usr/share/clearwater/bin/issue-alarm monit 1500.3; /usr/share/clearwater/bin/stop_or_abort homestead cx_health 86400'"
+  if status = 3 for 2 cycles then exec "/bin/bash -c '/usr/share/clearwater/infrastructure/monit_stability/homestead-stability aborted; /usr/share/clearwater/bin/issue-alarm monit 1500.3; /usr/share/clearwater/bin/stop_or_abort homestead cx_health 86400'"
 
 EOF
 chmod 0644 /etc/monit/conf.d/homestead.monit


### PR DESCRIPTION
This is a process-specific fix for [#59](https://github.com/ClearwaterCore/clearwater-infrastructure/pull/59).